### PR TITLE
修复 bg.png 因绝对路径问题可能无法加载的问题

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@
     </style>
 	<style>
 	body{
-        background-image:url('/bg.png');
+        background-image:url('./bg.png');
         background-repeat: no-repeat;
         background-position: center;
         background-size: cover;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46947952/117558519-c7568180-b0b0-11eb-8b27-57988e5593cb.png)
该问题会导致黑屏，原因是 /bg.png 在子目录下可能无法访问导致 404